### PR TITLE
Fix centering of `.message` during `.typing`.

### DIFF
--- a/src/views/components/style.scss
+++ b/src/views/components/style.scss
@@ -112,7 +112,7 @@ $client-text-color: #FFFFFF;
   transition: opacity 250ms ease-in-out, transform 250ms ease-in-out;
 }
 
-.typing {
+.typingIndicatorWrapper {
   text-align: center;
 
   .spinner {

--- a/src/views/components/typing-indicator.js
+++ b/src/views/components/typing-indicator.js
@@ -8,7 +8,7 @@ import style from './style.scss'
 
 class TypingIndicator extends React.Component {
   render() {
-    return <div className={style.typing}>
+    return <div className={style.typingIndicatorWrapper}>
       <Spinner name='ball-pulse-sync' fadeIn={'quarter'} className={style.spinner}/>
     </div>
   }


### PR DESCRIPTION
This fixes accidental centering of text in `.message`s during `.typing`.
Instead using specific class for wrapper div around typing indicator, that doesn't affect `.message`s.